### PR TITLE
Finished Initial setup of Ethernet and Bonding interface types. (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Specify filepatterns you want git to ignore.
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 VYOS
 =========
 
-Ansible role for VYOS routers.
+Ansible roles for VYOS routers.
+
+INTERFACE CONFIGURATION
+===
+
+Every available command should be configurable while using this playbook. If you don't know how to define a variable, please look in the variable templates. 

--- a/host_vars/template.yaml
+++ b/host_vars/template.yaml
@@ -1,0 +1,203 @@
+---
+# host_vars complete template
+#
+#    You can define all the variables for a host in this file, 
+#    or use the template folder structure and define individual 
+#    portions in separate files. Template folders are included
+#    that follows the correct folder/file structure, template_1
+#    separates variables by purpose, eg. interfaces, routing,
+#    firewall, etc. Template_2 separates variables more granularly
+#    e.g. ethernets, bonding, bgp, ospf, etc. These templates can
+#    be mixed and matched, just be sure to not define a variable
+#    in more than one place, otherwise unexpected behavior can
+#    occur.
+#
+---
+
+### ETHERNET CONFIGURATIONS ###
+
+ethernet:
+  - vyos_if: <interface name>
+    vlan: <vlan ID> # By setting a VLAN ID, all of the following settings apply only to that VLAN
+    enabled: <true | false>
+#    vrf: <default | vrf>
+    desc: <interface description>
+#    duplex: <auto | full | half> # Defaults to auto if not defined
+#    speed:  <auto | 10 | 100 | 1000 | 2500 | 5000 | 10000 | 25000 | 40000 | 50000 | 100000> # Defaults to auto if not defined
+    ipv4: <true | false>
+    ipv4_addr: <address | dhcp>
+    ipv6: <true | false>
+    ipv6_addr: <address | dhcpv6>
+#    mirror: <interface> # Mirror all inbound traffic to this interface
+#    ipv6_addr_autoconf: <true | false> # This disables IPv6 forwarding for this interface
+#    ipv6_eui64_prefix: <prefix>
+#    mac: <xx:xx:xx:xx:xx:xx>
+#    mtu: <MTU>
+#    disable_flow_control: <true | false>
+#    disable_link_detect: <true | false>
+#    ipv4_disable_forwarding: <true | false>
+#    ipv4_adjust_mss: <mss | clamp-mss-to-pmtu>
+#    arp_cache_timeout: 30 # time-in-seconds
+#    enable_directed_broadcast: <true | false>
+#    enable_arp_accept: <true | false>
+#    enable_arp_announce: <true | false>
+#    enable_arp_ignore: <true | false>
+#    enable_proxy_arp: <true | false>
+#    proxy_arp_pvlan: <true | false>
+#    source_validation_mode: <strict | loose | disable>
+#    ipv6_no_default_link_local: <true | false>
+#    ipv6_disable_forwarding: <true | false>
+#    ipv6_adjust_mss: <mss | clamp-mss-to-pmtu>
+#    dhcp_options:
+#      client_id: <description>
+#      host_name: <hostname> # only define if you want to set an alternative hostname to be used for DHCPv6 packets
+#      vendor_class_id: <vendor-id>
+#      no_default_route: <true | false>
+#      default_route_distance: 100
+#      reject: <address | cidr>
+#    dhcpv6_options:
+#      duid: <duid>
+#      parameters_only: <true | false>
+#      rapid_commit: <true | false>
+#      temporary: <true | false>
+#      prefix_delegation:
+#        pd: <ID>
+#        length: <length>
+#        delegate_prefix:
+#          sla_id: 
+#          delegate_interface: <interface to delegate prefix to>
+#          address: <address for delegated prefix> # These three parameters can be specified multiple times
+#    offloading: # Enable hardware offloading (must be supported by hardware)
+#      gro: <true | false>
+#      gso: <true | false>
+#      lro: <true | false>
+#      rps: <true | false>
+#      sg: <true | false>
+#      tso: <true | false>
+#    xdp: <true | false> # WARNING: HIGHLY EXPERIMENTAL FEATURE 
+#    eapol:   ### NOT YET IMPLEMENTED
+#      ca_certificate: <name>
+#      certificate: <name>
+
+
+### BONDING CONFIGURATION ###
+
+bonding:
+  - vyos_if: <interface name>
+    vlan: <vlan ID> # By setting a VLAN ID, all of the following settings apply only to that VLAN
+    enabled: <true | false>
+#    vrf: <default | vrf>
+    desc: <interface description>
+    members:
+      - <list members, one per line>
+    bonding_mode: <802.3ad | active-backup | broadcast | round-robin | transmit-load-balance | adaptive-load-balance | xor-hash>
+    bond_min_links: <0-16>
+    bond_lacp_rate: <slow | fast>
+    bond_hash_policy: <layer2 | layer2+3 | layer 3+4>
+    bond_primary_interface: <ethernet interface>
+    bond_arp_monitor_interval: <time in seconds>
+    bond_arp_monitor_target_address:
+      - <arp target address>
+    ipv4: <true | false>
+    ipv4_addr: <address | dhcp>
+    ipv6: <true | false>
+    ipv6_addr: <address | dhcpv6>
+    mirror: # Mirror all inbound traffic to this interface
+      ingress: <interface>
+      egress: <interface>
+#    ipv6_addr_autoconf: <true | false> # This disables IPv6 forwarding for this interface
+#    ipv6_eui64_prefix: <prefix>
+#    mac: <xx:xx:xx:xx:xx:xx>
+#    mtu: <MTU>
+#    disable_flow_control: <true | false>
+#    disable_link_detect: <true | false>
+#    ipv4_disable_forwarding: <true | false>
+#    ipv4_adjust_mss: <mss | clamp-mss-to-pmtu>
+#    arp_cache_timeout: 30 # time-in-seconds
+#    enable_directed_broadcast: <true | false>
+#    enable_arp_accept: <true | false>
+#    enable_arp_announce: <true | false>
+#    enable_arp_ignore: <true | false>
+#    enable_proxy_arp: <true | false>
+#    proxy_arp_pvlan: <true | false>
+#    disable_arp_filter: <true | false>
+#    source_validation_mode: <strict | loose | disable>
+#    ipv6_no_default_link_local: <true | false>
+#    ipv6_disable_forwarding: <true | false>
+#    ipv6_adjust_mss: <mss | clamp-mss-to-pmtu>
+#    dhcp_options:
+#      client_id: <description>
+#      host_name: <hostname> # only define if you want to set an alternative hostname to be used for DHCPv6 packets
+#      vendor_class_id: <vendor-id>
+#      no_default_route: <true | false>
+#      default_route_distance: 100
+#      reject: <address | cidr>
+#    dhcpv6_options:
+#      duid: <duid>
+#      parameters_only: <true | false>
+#      rapid_commit: <true | false>
+#      temporary: <true | false>
+#      prefix_delegation:
+#        pd: <ID>
+#        length: <length>
+#        delegate_prefix:
+#          sla_id: 
+#          delegate_interface: <interface to delegate prefix to>
+#          address: <address for delegated prefix> # These three parameters can be specified multiple times
+#    xdp: <true | false> # WARNING: HIGHLY EXPERIMENTAL FEATURE 
+
+### OPENVPN CONFIGURATION ###
+
+openvpn:
+
+### PPPoE CONFIGURATION ###
+
+pppoe:
+
+### BRIDGE CONFIGURATIONS ###
+
+bridge:
+
+### DUMMY CONFIGURATIONS ###
+
+dummy: 
+
+### TUNNEL CONFIGURATIONS ###
+
+tunnel:
+
+### WIREGUARD CONFIGURATIONS ###
+
+wireguard:
+
+### VXLAN CONFIGURATION ###
+
+vxlan:
+
+### WLAN/WIFI CONFIGURATION ###
+
+wlan:
+
+### WWAN CONFIGURATION ###
+
+wwan:
+
+### GENEVE CONFIGURATION ###
+
+geneve:
+
+### L2TPv3 CONFIGURATION ###
+
+l2tpv3:
+
+### Loopback CONFIGURATION ###
+
+loopback: 
+
+### MACSEC CONFIGURATION ###
+
+macsec:
+
+### VTI CONFIGURATION ###
+
+vti:

--- a/roles/interfaces/tasks/br.yaml
+++ b/roles/interfaces/tasks/br.yaml
@@ -1,0 +1,9 @@
+- name: Configure Bridge Interfaces
+  vyos_config:
+    src: br.j2
+  when:
+    - bridge is defined
+  tags:
+    - bridge
+    - bridge_v4
+    - bridge_v6

--- a/roles/interfaces/tasks/dum.yaml
+++ b/roles/interfaces/tasks/dum.yaml
@@ -1,0 +1,9 @@
+- name: Configure Dummy Interfaces
+  vyos_config:
+    src: dum.j2
+  when:
+    - dummy is defined
+  tags:
+    - dummy
+    - dummy_v4
+    - dummy_v6

--- a/roles/interfaces/tasks/main.yaml
+++ b/roles/interfaces/tasks/main.yaml
@@ -1,2 +1,10 @@
 ---
 # Interfaces Task List
+- name: 'Configure Ethernet Interfaces'
+  include_tasks: ethernet.yaml
+
+- name: 'Configure Bridge Interfaces'
+  include: br.yaml
+
+- name: 'Configure Dummy Interfaces'
+  include_tasks: dum.yaml

--- a/roles/interfaces/templates/bonding.j2
+++ b/roles/interfaces/templates/bonding.j2
@@ -1,0 +1,482 @@
+{% for bond in bonding %}
+{% if bond['vlan'] is not defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} description {{ bond['desc'] }}
+	set interfaces bonding {{ bond['vyos_if'] }} mode {{ bond['bonding_mode'] }}
+	set interfaces bonding {{ bond['vyos_if'] }} min-links {{ bond['bond_min_links'] }}
+	set interfaces bonding {{ bond['vyos_if'] }} lacp-rate {{ bond['bond_lacp_rate'] }}
+	set interfaces bonding {{ bond['vyos_if'] }} hash-policy {{ bond['bond_hash_policy'] }}
+	set interfaces bonding {{ bond['vyos_if'] }} primary {{ bond['bond_primary_interface'] }}
+{% if bond['bond_arp_monitor_interval'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} arp-monitor interval {{ bond['bond_arp_monitor_interval'] }}
+{% for target in bond['bond_arp_monitor_target_address'] %}
+	set interfaces bonding {{ bond['vyos_if'] }} arp monitor target {{ target }}
+{% endfor %}
+{% endif %}
+{% for member in bond['members'] %}
+set interfaces bonding {{ bond['vyos_if'] }} member interface {{ member }}
+{% endfor %}
+{% if bond['enabled'] is sameas false %}
+	set interfaces bonding {{ bond['vyos_if'] }} disable
+{% else %}
+	delete interfaces bonding {{ bond['vyos_if'] }} disable
+{% endif %}
+{% if bond['vrf'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} vrf {{ bond['vrf'] }}
+{% endif %}
+{% if bond['mac'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} mac '{{ bond['mac'] }}'
+{% endif %}
+{% if bond['mtu'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} mtu {{ bond['mtu'] }}
+{% endif %}
+{% if bond['ipv4'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} address '{{ bond['ipv4_addr'] }}'
+{% endif %}
+{% if bond['ipv6'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} address '{{ bond['ipv6_addr'] }}'
+{% endif %}
+{% if bond['mirror'] is defined %}
+{% if bond['mirror']['ingress'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} mirror ingress '{{ bond['mirror']['ingress'] }}'
+{% endif %}
+{% if bond['mirror']['egress'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} mirror egress '{{ bond['mirror']['egress'] }}'
+{% endif %}
+{% endif %}
+{% if bond['ipv6_addr_autoconf'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} ipv6 address autoconf
+{% endif %}
+{% if bond['ipv6_eui64_prefix'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} ipv6 address eui64 '{{ bond['ipv6_eui64_prefix'] }}'
+{% endif %}
+{% if bond['disable_flow_control'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} disable-flow-control
+{% else %}
+	delete interfaces bonding {{ bond['vyos_if'] }} disable-flow-control
+{% endif %}
+{% if bond['disable_link_detect'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} disable-link-detect
+{% else %}
+	delete interfaces bonding {{ bond['vyos_if'] }} disable-link-detect
+{% endif %}
+{% if bond['ipv4_disable_forwarding'] is defined %}
+{% if bond['ipv4_disable_forwarding'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} ip disable-forwarding
+{% endif %}
+{% if bond['ipv4_disable_forwarding'] is sameas false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} ip disable-forwarding
+{% endif %}
+{% endif %}
+{% if bond['disable_flow_control'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} disable-flow-control
+{% else %}
+	delete interfaces bonding {{ bond['vyos_if'] }} disable-flow-control
+{% endif %}
+{% if bond['ipv4_adjust_mss'] is defined %}
+{% if bond['ipv4_adjust_mss'] is sameas 'clamp-mss-to-pmtu' %}
+	set interfaces bonding {{ bond['vyos_if'] }} ip adjust-mss clamp-mss-to-pmtu
+{% else %}
+	set interfaces bonding {{ bond['vyos_if'] }} ip adjust-mss {{ bond['ipv4_adjust_mss'] }}
+{% endif %}
+{% endif %}
+{% if bond['arp_cache_timeout'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} ip arp-cache-timeout '{{ bond['arp_cache_timeout'] }}'
+{% else %}
+	set interfaces bonding {{ bond['vyos_if'] }} ip arp-cache-timeout 30
+{% endif %}
+{% if bond['enable_directed_broadcast'] is defined %}
+{% if bond['enable_directed_broadcast'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} ip enable-directed-broadcast
+{% endif %}
+{% if bond['enable_directed_broadcast'] is sameas false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} ip enable-directed-broadcast
+{% endif %}
+{% endif %}
+{% if bond['enable_arp_accept'] is defined %}
+{% if bond['enable_arp_accept'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} ip enable-arp-accept
+{% endif %}
+{% if bond['enable_arp_accept'] is sameas false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} ip enable-arp-accemt
+{% endif %}
+{% endif %}
+{% if bond['enable_arp_announce'] is defined %}
+{% if bond['enable_arp_announce'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} ip enable-arp-announce
+{% endif %}
+{% if bond['enable_arp_announce'] is sameas false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} ip enable-arp-announce
+{% endif %}
+{% endif %}
+{% if bond['enable_arp_ignore'] is defined %}
+{% if bond['enable_arp_ignore'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} ip enable-arp-ignore
+{% endif %}
+{% if bond['enable_arp_ignore'] is sameas false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} ip enable-arp-ignore
+{% endif %}
+{% endif %}
+{% if bond['enable_proxy_arp'] is defined %}
+{% if bond['enable_proxy_arp'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} ip enable-proxy-arp
+{% endif %}
+{% if bond['enable_proxy_arp'] is sameas false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} ip enable-proxy-arp
+{% endif %}
+{% endif %}
+{% if bond['proxy_arp_pvlan'] is defined %}
+{% if bond['proxy_arp_pvlan'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} ip proxy_arp_pvlan
+{% endif %}
+{% if bond['proxy_arp_pvlan'] is sameas false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} ip proxy_arp_pvlan
+{% endif %}
+{% endif %}
+
+{% if bond['disable_arp_filter'] == true %}
+	set interfaces bonding {{ bond['vyos_if'] }} ip disable-arp-filter
+{% endif %}
+{% if bond['disable_arp_filter'] == false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} ip disable-arp-filter
+{% endif %}
+
+{% if bond['source_validation_mode'] is defined %}
+{% if bond['source_validation_mode'] == 'strict' %}
+	set interfaces bonding {{ bond['vyos_if'] }} ip source-validation strict
+{% endif %}
+{% if bond['source_validation_mode'] == 'loose' %}
+	set interfaces bonding {{ bond['vyos_if'] }} ip source-validation loose
+{% endif %}
+{% if bond['source_validation_mode'] == 'disable' %}
+	set interfaces bonding {{ bond['vyos_if'] }} ip source-validation disable
+{% endif %}
+{% endif %}
+{% if bond['ipv6_no_default_link_local'] is defined %}
+{% if bond['ipv6_no_default_link_local'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} ipv6 address no-default-link-local
+{% endif %}
+{% if bond['ipv6_no_default_link_local'] is sameas false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} ipv6 address no-default-link-local
+{% endif %}
+{% endif %}
+{% if bond['ipv6_disable_forwarding'] is defined %}
+{% if bond['ipv6_disable_forwarding'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} ipv6 disable-forwarding
+{% endif %}
+{% if bond['ipv6_disable_forwarding'] is sameas false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} ipv6 disable-forwarding
+{% endif %}
+{% endif %}
+{% if bond['ipv6_adjust_mss'] is defined %}
+{% if bond['ipv6_adjust_mss'] is sameas 'clamp-mss-to-pmtu' %}
+	set interfaces bonding {{ bond['vyos_if'] }} ipv6 adjust-mss clamp-mss-to-pmtu
+{% else %}
+	set interfaces bonding {{ bond['vyos_if'] }} ipv6 adjust-mss {{ bond['ipv6_adjust_mss'] }}
+{% endif %}
+{% endif %}
+{% if bond['dhcp_options'] is defined %}
+{% if bond['dhcp_options']['client_id'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} dhcp-options client-id '{{ bond['dhcp_options']['client_id'] }}'
+{% endif %}
+{% if bond['dhcp_options']['host_name'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} dhcp-options host-name '{{ bond['dhcp_options']['host_name'] }}'
+{% endif %}
+{% if bond['dhcp_options']['vendor_class_id'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} dhcp-options vendor-class-id '{{ bond['dhcp_options']['vendor_class_id'] }}'
+{% endif %}
+{% if bond['dhcp_options']['no-default-route'] == true %}
+	set interfaces bonding {{ bond['vyos_if'] }} dhcp-options no-default-route
+{% endif %}
+{% if bond['dhcp_options']['default_route_distance'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} dhcp-options default-route-distance '{{ bond['dhcp_options']['default_route_distance'] }}'
+{% endif %}
+{% if bond['dhcp_options']['reject'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} dhcp-options reject '{{ bond['dhcp_options']['reject'] }}'
+{% endif %}
+{% endif %}
+{% if bond['dhcpv6_options'] is defined %}
+{% if bond['dhcpv6_options']['duid'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} dhcpv6-options duid '{{ bond['dhcpv6_options']['duid'] }}'
+{% endif %}
+{% if bond['dhcpv6_options']['parameters_only'] is defined %}
+{% if bond['dhcpv6_options']['parameters_only'] == true %}
+	set interfaces bonding {{ bond['vyos_if'] }} dhcpv6-options parameters-only
+{% endif %}
+{% if bond['dhcpv6_options']['parameters_only'] == false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} dhcpv6-options parameters-only
+{% endif %}
+{% endif %}
+{% if bond['dhcpv6_options']['rapid_commit'] is defined %}
+{% if bond['dhcpv6_options']['rapid_commit'] == true %}
+	set interfaces bonding {{ bond['vyos_if'] }} dhcpv6-options rapid-commit
+{% endif %}
+{% if bond['dhcpv6_options']['rapid_commit'] == false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} dhcpv6-options rapid-commit
+{% endif %}
+{% endif %}
+{% if bond['dhcpv6_options']['temporary'] is defined %}
+{% if bond['dhcpv6_options']['temporary'] == true %}
+	set interfaces bonding {{ bond['vyos_if'] }} dhcpv6-options temporary
+{% endif %}
+{% if bond['dhcpv6_options']['temporary'] == false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} dhcpv6-options temporary
+{% endif %}
+{% endif %}
+{% endif %}
+{% if bond['dhcpv6_options']['prefix_delegation'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} dhcpv6_options pd {{ bond['dhcpv6_options']['prefix_delegation']['pd]'] }} length {{ bond['dhcpv6_options']['prefix_delegation']['length'] }}
+{% for delegate in bond['dhcpv6_options']['prefix_delegation']['delegate_prefix']  %}
+	set interfaces bonding {{ bond['vyos_if'] }} dhcpv6_options pd {{ delegate['pd]'] }} interface {{ delegate['delegate_interface'] }} sla-id {{ delegate['sla_id'] }}
+	set interfaces bonding {{ bond['vyos_if'] }} dhcpv6_options pd {{ delegate['pd]'] }} interface {{ delegate['delegate_interface'] }} address {{ delegate['address'] }}
+{% endfor %}
+{% endif %}
+{% if bond['xdp'] is defined %}
+{% if bond['xdp'] == true %}
+	set interfaces bonding {{ bond['vyos_if'] }} xdp
+{% endif %}
+{% if bond['xdp'] == false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} xdp
+{% endif %}
+{% endif %}
+{% endif %}
+
+{% if bond['vlan'] is  defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} description {{ bond['desc'] }}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} mode {{ bond['bonding_mode'] }}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} min-links {{ bond['bond_min_links'] }}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} lacp-rate {{ bond['bond_lacp_rate'] }}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} hash-policy {{ bond['bond_hash_policy'] }}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} primary {{ bond['bond_primary_interface'] }}
+{% if bond['bond_arp_monitor_interval'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} arp-monitor interval {{ bond['bond_arp_monitor_interval'] }}
+{% for target in bond['bond_arp_monitor_target_address'] %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} arp monitor target {{ target }}
+{% endfor %}
+{% endif %}
+{% for member in bond['members'] %}
+set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} member interface {{ member }}
+{% if bond['enabled'] is sameas false %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} disable
+{% else %}
+	delete interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} disable
+{% endif %}
+{% if bond['vrf'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} vrf {{ bond['vrf'] }}
+{% endif %}
+{% if bond['mac'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} mac '{{ bond['mac'] }}'
+{% endif %}
+{% if bond['mtu'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} mtu {{ bond['mtu'] }}
+{% endif %}
+{% if bond['ipv4'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} address '{{ bond['ipv4_addr'] }}'
+{% endif %}
+{% if bond['ipv6'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} address '{{ bond['ipv6_addr'] }}'
+{% endif %}
+{% if bond['mirror'] is defined %}
+{% if bond['mirror']['ingress'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} mirror ingress '{{ bond['mirror']['ingress'] }}'
+{% endif %}
+{% if bond['mirror']['egress'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} mirror egress '{{ bond['mirror']['egress'] }}'
+{% endif %}
+{% endif %}
+{% if bond['ipv6_addr_autoconf'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ipv6 address autoconf
+{% endif %}
+{% if bond['ipv6_eui64_prefix'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ipv6 address eui64 '{{ bond['ipv6_eui64_prefix'] }}'
+{% endif %}
+{% if bond['disable_flow_control'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} disable-flow-control
+{% else %}
+	delete interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} disable-flow-control
+{% endif %}
+{% if bond['disable_link_detect'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} disable-link-detect
+{% else %}
+	delete interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} disable-link-detect
+{% endif %}
+{% if bond['ipv4_disable_forwarding'] is defined %}
+{% if bond['ipv4_disable_forwarding'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip disable-forwarding
+{% endif %}
+{% if bond['ipv4_disable_forwarding'] is sameas false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip disable-forwarding
+{% endif %}
+{% endif %}
+{% if bond['disable_flow_control'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} disable-flow-control
+{% else %}
+	delete interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} disable-flow-control
+{% endif %}
+{% if bond['ipv4_adjust_mss'] is defined %}
+{% if bond['ipv4_adjust_mss'] is sameas 'clamp-mss-to-pmtu' %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip adjust-mss clamp-mss-to-pmtu
+{% else %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip adjust-mss {{ bond['ipv4_adjust_mss'] }}
+{% endif %}
+{% endif %}
+{% if bond['arp_cache_timeout'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip arp-cache-timeout '{{ bond['arp_cache_timeout'] }}'
+{% else %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip arp-cache-timeout 30
+{% endif %}
+{% if bond['enable_directed_broadcast'] is defined %}
+{% if bond['enable_directed_broadcast'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip enable-directed-broadcast
+{% endif %}
+{% if bond['enable_directed_broadcast'] is sameas false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip enable-directed-broadcast
+{% endif %}
+{% endif %}
+{% if bond['enable_arp_accept'] is defined %}
+{% if bond['enable_arp_accept'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip enable-arp-accept
+{% endif %}
+{% if bond['enable_arp_accept'] is sameas false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip enable-arp-accemt
+{% endif %}
+{% endif %}
+{% if bond['enable_arp_announce'] is defined %}
+{% if bond['enable_arp_announce'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip enable-arp-announce
+{% endif %}
+{% if bond['enable_arp_announce'] is sameas false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip enable-arp-announce
+{% endif %}
+{% endif %}
+{% if bond['enable_arp_ignore'] is defined %}
+{% if bond['enable_arp_ignore'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip enable-arp-ignore
+{% endif %}
+{% if bond['enable_arp_ignore'] is sameas false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip enable-arp-ignore
+{% endif %}
+{% endif %}
+{% if bond['enable_proxy_arp'] is defined %}
+{% if bond['enable_proxy_arp'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip enable-proxy-arp
+{% endif %}
+{% if bond['enable_proxy_arp'] is sameas false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip enable-proxy-arp
+{% endif %}
+{% endif %}
+{% if bond['proxy_arp_pvlan'] is defined %}
+{% if bond['proxy_arp_pvlan'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip proxy_arp_pvlan
+{% endif %}
+{% if bond['proxy_arp_pvlan'] is sameas false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip proxy_arp_pvlan
+{% endif %}
+{% endif %}
+{% if bond['disable_arp_filter'] == true %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip disable-arp-filter
+{% endif %}
+{% if bond['disable_arp_filter'] == false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip disable-arp-filter
+{% endif %}
+{% if bond['source_validation_mode'] is defined %}
+{% if bond['source_validation_mode'] == 'strict' %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip source-validation strict
+{% endif %}
+{% if bond['source_validation_mode'] == 'loose' %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip source-validation loose
+{% endif %}
+{% if bond['source_validation_mode'] == 'disable' %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ip source-validation disable
+{% endif %}
+{% endif %}
+{% if bond['ipv6_no_default_link_local'] is defined %}
+{% if bond['ipv6_no_default_link_local'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ipv6 address no-default-link-local
+{% endif %}
+{% if bond['ipv6_no_default_link_local'] is sameas false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ipv6 address no-default-link-local
+{% endif %}
+{% endif %}
+{% if bond['ipv6_disable_forwarding'] is defined %}
+{% if bond['ipv6_disable_forwarding'] is sameas true %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ipv6 disable-forwarding
+{% endif %}
+{% if bond['ipv6_disable_forwarding'] is sameas false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ipv6 disable-forwarding
+{% endif %}
+{% endif %}
+{% if bond['ipv6_adjust_mss'] is defined %}
+{% if bond['ipv6_adjust_mss'] is sameas 'clamp-mss-to-pmtu' %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ipv6 adjust-mss clamp-mss-to-pmtu
+{% else %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} ipv6 adjust-mss {{ bond['ipv6_adjust_mss'] }}
+{% endif %}
+{% endif %}
+{% if bond['dhcp_options'] is defined %}
+{% if bond['dhcp_options']['client_id'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} dhcp-options client-id '{{ bond['dhcp_options']['client_id'] }}'
+{% endif %}
+{% if bond['dhcp_options']['host_name'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} dhcp-options host-name '{{ bond['dhcp_options']['host_name'] }}'
+{% endif %}
+{% if bond['dhcp_options']['vendor_class_id'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} dhcp-options vendor-class-id '{{ bond['dhcp_options']['vendor_class_id'] }}'
+{% endif %}
+{% if bond['dhcp_options']['no-default-route'] == true %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} dhcp-options no-default-route
+{% endif %}
+{% if bond['dhcp_options']['default_route_distance'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} dhcp-options default-route-distance '{{ bond['dhcp_options']['default_route_distance'] }}'
+{% endif %}
+{% if bond['dhcp_options']['reject'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} dhcp-options reject '{{ bond['dhcp_options']['reject'] }}'
+{% endif %}
+{% endif %}
+{% if bond['dhcpv6_options'] is defined %}
+{% if bond['dhcpv6_options']['duid'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} dhcpv6-options duid '{{ bond['dhcpv6_options']['duid'] }}'
+{% endif %}
+{% if bond['dhcpv6_options']['parameters_only'] is defined %}
+{% if bond['dhcpv6_options']['parameters_only'] == true %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} dhcpv6-options parameters-only
+{% endif %}
+{% if bond['dhcpv6_options']['parameters_only'] == false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} dhcpv6-options parameters-only
+{% endif %}
+{% endif %}
+{% if bond['dhcpv6_options']['rapid_commit'] is defined %}
+{% if bond['dhcpv6_options']['rapid_commit'] == true %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} dhcpv6-options rapid-commit
+{% endif %}
+{% if bond['dhcpv6_options']['rapid_commit'] == false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} dhcpv6-options rapid-commit
+{% endif %}
+{% endif %}
+{% if bond['dhcpv6_options']['temporary'] is defined %}
+{% if bond['dhcpv6_options']['temporary'] == true %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} dhcpv6-options temporary
+{% endif %}
+{% if bond['dhcpv6_options']['temporary'] == false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} dhcpv6-options temporary
+{% endif %}
+{% endif %}
+{% endif %}
+{% if bond['dhcpv6_options']['prefix_delegation'] is defined %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} dhcpv6_options pd {{ bond['dhcpv6_options']['prefix_delegation']['pd]'] }} length {{ bond['dhcpv6_options']['prefix_delegation']['length'] }}
+{% for delegate in bond['dhcpv6_options']['prefix_delegation']['delegate_prefix']  %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} dhcpv6_options pd {{ delegate['pd]'] }} interface {{ delegate['delegate_interface'] }} sla-id {{ delegate['sla_id'] }}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} dhcpv6_options pd {{ delegate['pd]'] }} interface {{ delegate['delegate_interface'] }} address {{ delegate['address'] }}
+{% endfor %}
+{% endif %}
+{% if bond['xdp'] is defined %}
+{% if bond['xdp'] == true %}
+	set interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} xdp
+{% endif %}
+{% if bond['xdp'] == false %}
+	delete interfaces bonding {{ bond['vyos_if'] }} vif {{ bond['vlan'] }} xdp
+{% endif %}
+{% endif %}
+{% endif %}
+{% endif %}
+{% endif %}
+{% endfor %}

--- a/roles/interfaces/templates/br.j2
+++ b/roles/interfaces/templates/br.j2
@@ -1,0 +1,26 @@
+{% for bridge in bridge %}
+{% if bridge['enabled'] is sameas True %}
+set interfaces bridge {{ bridge['vyos_if'] }} description '{{ bridge['desc'] }}'
+{% if bridge['ipv4'] is sameas true %}
+set interfaces bridge {{ bridge['vyos_if'] }} address {{ bridge['ipv4_addr'] }}
+{% endif %}
+{% if bridge['ipv6'] is sameas true %}
+set interfaces bridge {{ bridge['vyos_if'] }} address {{ bridge['ipv6_addr'] }}
+{% endif %}
+{% if bridge['member1'] is defined %}
+set interfaces bridge {{ bridge['vyos_if'] }} member interface {{ bridge['member1'] }}
+{% endif %}
+{% if bridge['member2'] is defined %}
+set interfaces bridge {{ bridge['vyos_if'] }} member interface {{ bridge['member2'] }}
+{% endif %}
+{% if bridge['member3'] is defined %}
+set interfaces bridge {{ bridge['vyos_if'] }} member interface {{ bridge['member3'] }}
+{% endif %}
+{% if bridge['member4'] is defined %}
+set interfaces bridge {{ bridge['vyos_if'] }} member interface {{ bridge['member4'] }}
+{% endif %}
+{% if bridge['member5'] is defined %}
+set interfaces bridge {{ bridge['vyos_if'] }} member interface {{ bridge['member5'] }}
+{% endif %}
+{% endif %}
+{% endfor %}

--- a/roles/interfaces/templates/dum.j2
+++ b/roles/interfaces/templates/dum.j2
@@ -1,0 +1,11 @@
+{% for dummy in dummy %}
+{% if dummy['enabled'] is sameas True %}
+set interfaces dummy {{ dummy['vyos_if'] }} description '{{ dummy['desc'] }}'
+{% if bridge['ipv4'] is sameas true %}
+set interfaces dummy {{ dummy['vyos_if'] }} address {{ dummy['ipv4_addr'] }}
+{% endif %}
+{% if dummy['ipv6'] is sameas true %}
+set interfaces dummy {{ dummy['vyos_if'] }} address {{ dummy['ipv6_addr'] }}
+{% endif %}
+{% endif %}
+{% endfor %}

--- a/roles/interfaces/templates/eth.j2
+++ b/roles/interfaces/templates/eth.j2
@@ -1,0 +1,544 @@
+{% for eth in ethernet %}
+{% if eth['vlan'] is not defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} description {{ eth['desc'] }}
+{% if eth['enabled'] is sameas false %}
+	set interfaces ethernet {{ eth['vyos_if'] }} disable
+{% else %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} disable
+{% endif %}
+{% if eth['vrf'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vrf {{ eth['vrf'] }}
+{% endif %}
+{% if eth['mac'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} mac '{{ eth['mac'] }}'
+{% endif %}
+{% if eth['duplex'] == 'auto' %}
+	set interfaces ethernet {{ eth['vyos_if'] }} duplex 'auto'
+{% endif %}
+{% if eth['duplex'] == 'full' %}
+	set interfaces ethernet {{ eth['vyos_if'] }} duplex 'full'
+{% endif %}
+{% if eth['duplex'] == 'half' %}
+	set interfaces ethernet {{ eth['vyos_if'] }} duplex 'half'
+{% endif %}
+{% if eth['duplex'] is not defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} duplex 'auto'
+{% endif %}
+{% if eth['speed'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} speed '{{ eth['speed'] }}'
+{% else %}
+	set interfaces ethernet {{ eth['vyos_if'] }} speed 'auto'
+{% endif %}
+{% if eth['mtu'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} mtu {{ eth['mtu'] }}
+{% endif %}
+{% if eth['ipv4'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} address '{{ eth['ipv4_addr'] }}'
+{% endif %}
+{% if eth['ipv6'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} address '{{ eth['ipv6_addr'] }}'
+{% endif %}
+{% if eth['mirror'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} mirror '{{ eth['mirror'] }}'
+{% endif %}
+{% if eth['ipv6_addr_autoconf'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} ipv6 address autoconf
+{% endif %}
+{% if eth['ipv6_eui64_prefix'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} ipv6 address eui64 '{{ eth['ipv6_eui64_prefix'] }}'
+{% endif %}
+{% if eth['disable_flow_control'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} disable-flow-control
+{% else %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} disable-flow-control
+{% endif %}
+{% if eth['disable_link_detect'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} disable-link-detect
+{% else %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} disable-link-detect
+{% endif %}
+{% if eth['ipv4_disable_forwarding'] is defined %}
+{% if eth['ipv4_disable_forwarding'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} ip disable-forwarding
+{% endif %}
+{% if eth['ipv4_disable_forwarding'] is sameas false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} ip disable-forwarding
+{% endif %}
+{% endif %}
+{% if eth['disable_flow_control'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} disable-flow-control
+{% else %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} disable-flow-control
+{% endif %}
+{% if eth['ipv4_adjust_mss'] is defined %}
+{% if eth['ipv4_adjust_mss'] is sameas 'clamp-mss-to-pmtu' %}
+	set interfaces ethernet {{ eth['vyos_if'] }} ip adjust-mss clamp-mss-to-pmtu
+{% else %}
+	set interfaces ethernet {{ eth['vyos_if'] }} ip adjust-mss {{ eth['ipv4_adjust_mss'] }}
+{% endif %}
+{% endif %}
+{% if eth['arp_cache_timeout'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} ip arp-cache-timeout '{{ eth['arp_cache_timeout'] }}'
+{% else %}
+	set interfaces ethernet {{ eth['vyos_if'] }} ip arp-cache-timeout 30
+{% endif %}
+{% if eth['enable_directed_broadcast'] is defined %}
+{% if eth['enable_directed_broadcast'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} ip enable-directed-broadcast
+{% endif %}
+{% if eth['enable_directed_broadcast'] is sameas false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} ip enable-directed-broadcast
+{% endif %}
+{% endif %}
+{% if eth['enable_arp_accept'] is defined %}
+{% if eth['enable_arp_accept'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} ip enable-arp-accept
+{% endif %}
+{% if eth['enable_arp_accept'] is sameas false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} ip enable-arp-accemt
+{% endif %}
+{% endif %}
+{% if eth['enable_arp_announce'] is defined %}
+{% if eth['enable_arp_announce'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} ip enable-arp-announce
+{% endif %}
+{% if eth['enable_arp_announce'] is sameas false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} ip enable-arp-announce
+{% endif %}
+{% endif %}
+{% if eth['enable_arp_ignore'] is defined %}
+{% if eth['enable_arp_ignore'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} ip enable-arp-ignore
+{% endif %}
+{% if eth['enable_arp_ignore'] is sameas false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} ip enable-arp-ignore
+{% endif %}
+{% endif %}
+{% if eth['enable_proxy_arp'] is defined %}
+{% if eth['enable_proxy_arp'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} ip enable-proxy-arp
+{% endif %}
+{% if eth['enable_proxy_arp'] is sameas false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} ip enable-proxy-arp
+{% endif %}
+{% endif %}
+{% if eth['proxy_arp_pvlan'] is defined %}
+{% if eth['proxy_arp_pvlan'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} ip proxy_arp_pvlan
+{% endif %}
+{% if eth['proxy_arp_pvlan'] is sameas false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} ip proxy_arp_pvlan
+{% endif %}
+{% endif %}
+{% if eth['source_validation_mode'] is defined %}
+{% if eth['source_validation_mode'] == 'strict' %}
+	set interfaces ethernet {{ eth['vyos_if'] }} ip source-validation strict
+{% endif %}
+{% if eth['source_validation_mode'] == 'loose' %}
+	set interfaces ethernet {{ eth['vyos_if'] }} ip source-validation loose
+{% endif %}
+{% if eth['source_validation_mode'] == 'disable' %}
+	set interfaces ethernet {{ eth['vyos_if'] }} ip source-validation disable
+{% endif %}
+{% endif %}
+{% if eth['ipv6_no_default_link_local'] is defined %}
+{% if eth['ipv6_no_default_link_local'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} ipv6 address no-default-link-local
+{% endif %}
+{% if eth['ipv6_no_default_link_local'] is sameas false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} ipv6 address no-default-link-local
+{% endif %}
+{% endif %}
+{% if eth['ipv6_disable_forwarding'] is defined %}
+{% if eth['ipv6_disable_forwarding'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} ipv6 disable-forwarding
+{% endif %}
+{% if eth['ipv6_disable_forwarding'] is sameas false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} ipv6 disable-forwarding
+{% endif %}
+{% endif %}
+{% if eth['ipv6_adjust_mss'] is defined %}
+{% if eth['ipv6_adjust_mss'] is sameas 'clamp-mss-to-pmtu' %}
+	set interfaces ethernet {{ eth['vyos_if'] }} ipv6 adjust-mss clamp-mss-to-pmtu
+{% else %}
+	set interfaces ethernet {{ eth['vyos_if'] }} ipv6 adjust-mss {{ eth['ipv6_adjust_mss'] }}
+{% endif %}
+{% endif %}
+{% if eth['dhcp_options'] is defined %}
+{% if eth['dhcp_options']['client_id'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} dhcp-options client-id '{{ eth['dhcp_options']['client_id'] }}'
+{% endif %}
+{% if eth['dhcp_options']['host_name'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} dhcp-options host-name '{{ eth['dhcp_options']['host_name'] }}'
+{% endif %}
+{% if eth['dhcp_options']['vendor_class_id'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} dhcp-options vendor-class-id '{{ eth['dhcp_options']['vendor_class_id'] }}'
+{% endif %}
+{% if eth['dhcp_options']['no-default-route'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} dhcp-options no-default-route
+{% endif %}
+{% if eth['dhcp_options']['default_route_distance'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} dhcp-options default-route-distance '{{ eth['dhcp_options']['default_route_distance'] }}'
+{% endif %}
+{% if eth['dhcp_options']['reject'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} dhcp-options reject '{{ eth['dhcp_options']['reject'] }}'
+{% endif %}
+{% endif %}
+{% if eth['dhcpv6_options'] is defined %}
+{% if eth['dhcpv6_options']['duid'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} dhcpv6-options duid '{{ eth['dhcpv6_options']['duid'] }}'
+{% endif %}
+{% if eth['dhcpv6_options']['parameters_only'] is defined %}
+{% if eth['dhcpv6_options']['parameters_only'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} dhcpv6-options parameters-only
+{% endif %}
+{% if eth['dhcpv6_options']['parameters_only'] == false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} dhcpv6-options parameters-only
+{% endif %}
+{% endif %}
+{% if eth['dhcpv6_options']['rapid_commit'] is defined %}
+{% if eth['dhcpv6_options']['rapid_commit'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} dhcpv6-options rapid-commit
+{% endif %}
+{% if eth['dhcpv6_options']['rapid_commit'] == false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} dhcpv6-options rapid-commit
+{% endif %}
+{% endif %}
+{% if eth['dhcpv6_options']['temporary'] is defined %}
+{% if eth['dhcpv6_options']['temporary'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} dhcpv6-options temporary
+{% endif %}
+{% if eth['dhcpv6_options']['temporary'] == false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} dhcpv6-options temporary
+{% endif %}
+{% endif %}
+{% endif %}
+{% if eth['dhcpv6_options']['prefix_delegation'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} dhcpv6_options pd {{ eth['dhcpv6_options']['prefix_delegation']['pd]'] }} length {{ eth['dhcpv6_options']['prefix_delegation']['length'] }}
+{% for delegate in eth['dhcpv6_options']['prefix_delegation']['delegate_prefix']  %}
+	set interfaces ethernet {{ eth['vyos_if'] }} dhcpv6_options pd {{ delegate['pd]'] }} interface {{ delegate['delegate_interface'] }} sla-id {{ delegate['sla_id'] }}
+	set interfaces ethernet {{ eth['vyos_if'] }} dhcpv6_options pd {{ delegate['pd]'] }} interface {{ delegate['delegate_interface'] }} address {{ delegate['address'] }}
+{% endfor %}
+{% endif %}
+{% if eth['offloading'] is defined %}
+{% if eth['offloading']['gro'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} offload gro
+{% else %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} offload gro
+{% endif %}
+{% if eth['offloading']['gso'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} offload gso
+{% else %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} offload gso
+{% endif %}
+{% if eth['offloading']['lro'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} offload lro
+{% else %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} offload lro
+{% endif %}
+{% if eth['offloading']['lrs'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} offload rps
+{% else %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} offload rps
+{% endif %}
+{% if eth['offloading']['sg'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} offload sg
+{% else %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} offload sg
+{% endif %}
+{% if eth['offloading']['tso'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} offload tso
+{% else %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} offload tso
+{% endif %}
+{% endif %}
+{% if eth['xdp'] is defined %}
+{% if eth['xdp'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} xdp
+{% endif %}
+{% if eth['xdp'] == false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} xdp
+{% endif %}
+{% endif %}
+{% if eth['eapol'] is defined %}
+{% if eth['eapol']['ca_certificate'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} eapol ca-certificate {{ eth['eapol']['ca_certificate'] }}
+{% endif %}
+{% if eth['eapol']['certificate'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} eapol certificate {{ eth['eapol']['certificate'] }}
+{% endif %}
+{% endif %}
+{% endif %}
+
+{% if eth['vlan'] is  defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} description {{ eth['desc'] }}
+{% if eth['enabled'] is sameas false %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} disable
+{% else %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} disable
+{% endif %}
+{% if eth['vrf'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} vrf {{ eth['vrf'] }}
+{% endif %}
+{% if eth['mac'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} mac '{{ eth['mac'] }}'
+{% endif %}
+{% if eth['duplex'] == 'auto' %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} duplex 'auto'
+{% endif %}
+{% if eth['duplex'] == 'full' %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} duplex 'full'
+{% endif %}
+{% if eth['duplex'] == 'half' %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} duplex 'half'
+{% endif %}
+{% if eth['duplex'] is not defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} duplex 'auto'
+{% endif %}
+{% if eth['speed'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} speed '{{ eth['speed'] }}'
+{% else %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} speed 'auto'
+{% endif %}
+{% if eth['mtu'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} mtu {{ eth['mtu'] }}
+{% endif %}
+{% if eth['ipv4'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} address '{{ eth['ipv4_addr'] }}'
+{% endif %}
+{% if eth['ipv6'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} address '{{ eth['ipv6_addr'] }}'
+{% endif %}
+{% if eth['mirror'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} mirror '{{ eth['mirror'] }}'
+{% endif %}
+{% if eth['ipv6_addr_autoconf'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ipv6 address autoconf
+{% endif %}
+{% if eth['ipv6_eui64_prefix'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ipv6 address eui64 '{{ eth['ipv6_eui64_prefix'] }}'
+{% endif %}
+{% if eth['disable_flow_control'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} disable-flow-control
+{% else %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} disable-flow-control
+{% endif %}
+{% if eth['disable_link_detect'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} disable-link-detect
+{% else %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} disable-link-detect
+{% endif %}
+{% if eth['ipv4_disable_forwarding'] is defined %}
+{% if eth['ipv4_disable_forwarding'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ip disable-forwarding
+{% endif %}
+{% if eth['ipv4_disable_forwarding'] is sameas false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ip disable-forwarding
+{% endif %}
+{% endif %}
+{% if eth['disable_flow_control'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} disable-flow-control
+{% else %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} disable-flow-control
+{% endif %}
+{% if eth['ipv4_adjust_mss'] is defined %}
+{% if eth['ipv4_adjust_mss'] is sameas 'clamp-mss-to-pmtu' %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ip adjust-mss clamp-mss-to-pmtu
+{% else %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ip adjust-mss {{ eth['ipv4_adjust_mss'] }}
+{% endif %}
+{% endif %}
+{% if eth['arp_cache_timeout'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ip arp-cache-timeout '{{ eth['arp_cache_timeout'] }}'
+{% else %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ip arp-cache-timeout 30
+{% endif %}
+{% if eth['enable_directed_broadcast'] is defined %}
+{% if eth['enable_directed_broadcast'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ip enable-directed-broadcast
+{% endif %}
+{% if eth['enable_directed_broadcast'] is sameas false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ip enable-directed-broadcast
+{% endif %}
+{% endif %}
+{% if eth['enable_arp_accept'] is defined %}
+{% if eth['enable_arp_accept'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ip enable-arp-accept
+{% endif %}
+{% if eth['enable_arp_accept'] is sameas false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ip enable-arp-accemt
+{% endif %}
+{% endif %}
+{% if eth['enable_arp_announce'] is defined %}
+{% if eth['enable_arp_announce'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ip enable-arp-announce
+{% endif %}
+{% if eth['enable_arp_announce'] is sameas false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ip enable-arp-announce
+{% endif %}
+{% endif %}
+{% if eth['enable_arp_ignore'] is defined %}
+{% if eth['enable_arp_ignore'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ip enable-arp-ignore
+{% endif %}
+{% if eth['enable_arp_ignore'] is sameas false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ip enable-arp-ignore
+{% endif %}
+{% endif %}
+{% if eth['enable_proxy_arp'] is defined %}
+{% if eth['enable_proxy_arp'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ip enable-proxy-arp
+{% endif %}
+{% if eth['enable_proxy_arp'] is sameas false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ip enable-proxy-arp
+{% endif %}
+{% endif %}
+{% if eth['proxy_arp_pvlan'] is defined %}
+{% if eth['proxy_arp_pvlan'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ip proxy_arp_pvlan
+{% endif %}
+{% if eth['proxy_arp_pvlan'] is sameas false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ip proxy_arp_pvlan
+{% endif %}
+{% endif %}
+{% if eth['source_validation_mode'] is defined %}
+{% if eth['source_validation_mode'] == 'strict' %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ip source-validation strict
+{% endif %}
+{% if eth['source_validation_mode'] == 'loose' %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ip source-validation loose
+{% endif %}
+{% if eth['source_validation_mode'] == 'disable' %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ip source-validation disable
+{% endif %}
+{% endif %}
+{% if eth['ipv6_no_default_link_local'] is defined %}
+{% if eth['ipv6_no_default_link_local'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ipv6 address no-default-link-local
+{% endif %}
+{% if eth['ipv6_no_default_link_local'] is sameas false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ipv6 address no-default-link-local
+{% endif %}
+{% endif %}
+{% if eth['ipv6_disable_forwarding'] is defined %}
+{% if eth['ipv6_disable_forwarding'] is sameas true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ipv6 disable-forwarding
+{% endif %}
+{% if eth['ipv6_disable_forwarding'] is sameas false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ipv6 disable-forwarding
+{% endif %}
+{% endif %}
+{% if eth['ipv6_adjust_mss'] is defined %}
+{% if eth['ipv6_adjust_mss'] is sameas 'clamp-mss-to-pmtu' %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ipv6 adjust-mss clamp-mss-to-pmtu
+{% else %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} ipv6 adjust-mss {{ eth['ipv6_adjust_mss'] }}
+{% endif %}
+{% endif %}
+{% if eth['dhcp_options'] is defined %}
+{% if eth['dhcp_options']['client_id'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} dhcp-options client-id '{{ eth['dhcp_options']['client_id'] }}'
+{% endif %}
+{% if eth['dhcp_options']['host_name'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} dhcp-options host-name '{{ eth['dhcp_options']['host_name'] }}'
+{% endif %}
+{% if eth['dhcp_options']['vendor_class_id'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} dhcp-options vendor-class-id '{{ eth['dhcp_options']['vendor_class_id'] }}'
+{% endif %}
+{% if eth['dhcp_options']['no-default-route'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} dhcp-options no-default-route
+{% endif %}
+{% if eth['dhcp_options']['default_route_distance'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} dhcp-options default-route-distance '{{ eth['dhcp_options']['default_route_distance'] }}'
+{% endif %}
+{% if eth['dhcp_options']['reject'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} dhcp-options reject '{{ eth['dhcp_options']['reject'] }}'
+{% endif %}
+{% endif %}
+{% if eth['dhcpv6_options'] is defined %}
+{% if eth['dhcpv6_options']['duid'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} dhcpv6-options duid '{{ eth['dhcpv6_options']['duid'] }}'
+{% endif %}
+{% if eth['dhcpv6_options']['parameters_only'] is defined %}
+{% if eth['dhcpv6_options']['parameters_only'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} dhcpv6-options parameters-only
+{% endif %}
+{% if eth['dhcpv6_options']['parameters_only'] == false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} dhcpv6-options parameters-only
+{% endif %}
+{% endif %}
+{% if eth['dhcpv6_options']['rapid_commit'] is defined %}
+{% if eth['dhcpv6_options']['rapid_commit'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} dhcpv6-options rapid-commit
+{% endif %}
+{% if eth['dhcpv6_options']['rapid_commit'] == false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} dhcpv6-options rapid-commit
+{% endif %}
+{% endif %}
+{% if eth['dhcpv6_options']['temporary'] is defined %}
+{% if eth['dhcpv6_options']['temporary'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} dhcpv6-options temporary
+{% endif %}
+{% if eth['dhcpv6_options']['temporary'] == false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} dhcpv6-options temporary
+{% endif %}
+{% endif %}
+{% endif %}
+{% if eth['dhcpv6_options']['prefix_delegation'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} dhcpv6_options pd {{ eth['dhcpv6_options']['prefix_delegation']['pd]'] }} length {{ eth['dhcpv6_options']['prefix_delegation']['length'] }}
+{% for delegate in eth['dhcpv6_options']['prefix_delegation']['delegate_prefix']  %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} dhcpv6_options pd {{ delegate['pd]'] }} interface {{ delegate['delegate_interface'] }} sla-id {{ delegate['sla_id'] }}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} dhcpv6_options pd {{ delegate['pd]'] }} interface {{ delegate['delegate_interface'] }} address {{ delegate['address'] }}
+{% endfor %}
+{% endif %}
+{% if eth['offloading'] is defined %}
+{% if eth['offloading']['gro'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} offload gro
+{% else %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} offload gro
+{% endif %}
+{% if eth['offloading']['gso'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} offload gso
+{% else %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} offload gso
+{% endif %}
+{% if eth['offloading']['lro'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} offload lro
+{% else %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} offload lro
+{% endif %}
+{% if eth['offloading']['lrs'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} offload rps
+{% else %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} offload rps
+{% endif %}
+{% if eth['offloading']['sg'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} offload sg
+{% else %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} offload sg
+{% endif %}
+{% if eth['offloading']['tso'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} offload tso
+{% else %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} offload tso
+{% endif %}
+{% endif %}
+{% if eth['xdp'] is defined %}
+{% if eth['xdp'] == true %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} xdp
+{% endif %}
+{% if eth['xdp'] == false %}
+	delete interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} xdp
+{% endif %}
+{% endif %}
+{% if eth['eapol'] is defined %}
+{% if eth['eapol']['ca_certificate'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} eapol ca-certificate {{ eth['eapol']['ca_certificate'] }}
+{% endif %}
+{% if eth['eapol']['certificate'] is defined %}
+	set interfaces ethernet {{ eth['vyos_if'] }} vif {{ eth['vlan'] }} eapol certificate {{ eth['eapol']['certificate'] }}
+{% endif %}
+{% endif %}
+{% endif %}
+
+{% endfor %}


### PR DESCRIPTION
* Updated Interfaces Configuration

Added Initial jinja2 templates for bridge interface and dummy interface configuration.

* Added .DS_Store to .gitignore

* Added All Ethernet Interface options, except for QinQ options.

* Updated README

* Added Jinja2 eth template

* Finished ethernet configuration jinja2 template

All Ethernet parameters configurable via host_vars except for QinQ.

* Added bonding jinja template and bonding variables to template

* Finished initial bonding jinja template

* Fixed Ethernet Configuration in main.yaml

Co-authored-by: Gabriel Tackitt <gabriel@tackitt.us>