### PR TITLE
Removed wireguard peer description

### DIFF
--- a/roles/interfaces/templates/wireguard.j2
+++ b/roles/interfaces/templates/wireguard.j2
@@ -172,7 +172,6 @@
 
 
 {% for peer in wg['peers'] %}
-	set interfaces wireguard {{ wg['vyos_if'] }} peer {{ peer['peer_name'] }} description {{ peer['peer_desc'] }}
 	set interfaces wireguard {{ wg['vyos_if'] }} peer {{ peer['peer_name'] }} address {{ peer['peer_endpoint_address'] }}
 	set interfaces wireguard {{ wg['vyos_if'] }} peer {{ peer['peer_name'] }} port {{ peer['peer_endpoint_port'] }}
 	set interfaces wireguard {{ wg['vyos_if'] }} peer {{ peer['peer_name'] }} public-key {{ peer['peer_public_key'] }}


### PR DESCRIPTION
removed wireguard peer description lines from wireguard.j2, peer description is not a valid parameter in VyOS. Left the peer description line in the template file, as this could still be used to for describing the peer in the configuration file.